### PR TITLE
reverse proxy can now start without nextjs

### DIFF
--- a/src/reverse-proxy/production/nginx.conf
+++ b/src/reverse-proxy/production/nginx.conf
@@ -8,11 +8,6 @@ events {
 http {
     include mime.types; # add mimetypes based on file extensions
 
-    upstream nextjs_upstream {
-        server web-app:3000;
-        keepalive 64;
-    }
-
     server {
         # it's necessary that this port matches the one that is published in the docker-compose.yml
         # i.e. the mapping has to look like this: 80:80 (otherwise certain built-in redirects won't work properly)
@@ -30,7 +25,11 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
 
-            proxy_pass http://nextjs_upstream/;
+            # pass address indirectly via variable to use resolver
+            # if we did not use resolver, nginx would shutdown if the upstream  is not available
+            # https://sandro-keil.de/blog/let-nginx-start-if-upstream-host-is-unavailable-or-down/
+            set $upstream http://web-app:3000;
+            proxy_pass $upstream;
             proxy_redirect off;
             proxy_read_timeout 240s;
         }


### PR DESCRIPTION
The open source version of nginx does not allow dynamic resolution of upstreams. This means that if any of the upstreams is not available on startup, the server exits. We work around this using a trick.