### PR TITLE
Feature/formio via nginx

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,6 +37,8 @@ services:
   formio:
     environment:
       DEBUG: formio:*
+    ports:
+      - 3001:3001
   mongo:
     ports:
       - 27017:27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
     restart: on-failure
     depends_on:
       - mongo
-    ports:
-      - "3001:3001"
     # TODO: this is horrible design by form.io, trying to communicate with them to remove this
     volumes:
       - ./src/formio/:/app:rw

--- a/src/reverse-proxy/production/nginx.conf
+++ b/src/reverse-proxy/production/nginx.conf
@@ -55,5 +55,22 @@ http {
             allow 127.0.0.0/16;	# only allow requests from localhost
             deny all;		# deny all other hosts
         }
+
+        location /formio/ {
+            # useful links:
+            # https://help.form.io/deployments/deployment-configurations
+            # https://help.form.io/deployments/load-balancer-configuration
+            proxy_set_header    Host $host;
+            proxy_set_header    X-Real-IP $remote_addr;
+            proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header    X-Forwarded-Proto $scheme;
+            proxy_read_timeout  90;
+
+            # HACK: when using the trick with the resolver,
+            # the app breaks (=> if formio is not available, nginx will not start)
+            proxy_pass http://formio:3001/;
+
+            proxy_redirect http://formio:3001 https://$host;
+        }
     }
 }


### PR DESCRIPTION
Zakázání přímého přístupu do formio a poskytnutí přístupu do formio skrze reverse proxy nginx. Přímý přístup je stále povolen v dev módu.